### PR TITLE
Framework introduction

### DIFF
--- a/multiply_prior_engine/__init__.py
+++ b/multiply_prior_engine/__init__.py
@@ -1,3 +1,5 @@
+from .soilmoisture_prior_creator import SoilMoisturePriorCreator, RoughnessPriorCreator
+from .vegetation_prior_creator import VegetationPriorCreator
 from .prior_engine import PriorEngine
 # from .prior_engine import *
 # from .prior import *

--- a/multiply_prior_engine/prior_creator.py
+++ b/multiply_prior_engine/prior_creator.py
@@ -11,6 +11,7 @@
 from abc import ABCMeta, abstractmethod
 import datetime
 from dateutil.parser import parse
+from typing import List
 import numpy as np
 
 __author__ = ["Alexander Löw", "Thomas Ramsauer"]
@@ -24,6 +25,7 @@ __status__ = "Prototype"
 
 
 class PriorCreator(metaclass=ABCMeta):
+
     def __init__(self, **kwargs):
         self.ptype = kwargs.get('ptype', None)
         self.config = kwargs.get('config', None)
@@ -35,6 +37,7 @@ class PriorCreator(metaclass=ABCMeta):
 
     def _check(self):
         assert self.ptype is not None, 'Invalid prior type'
+        #TODO make use of config optional
         assert self.config is not None, 'No config available.'
 
     def _create_time_vector(self):
@@ -56,9 +59,6 @@ class PriorCreator(metaclass=ABCMeta):
         if type(e) is str:
             e = datetime.datetime.strptime(e, date_format)
         t_span = (e-s).days + 1
-        # print(t_span)
-
-        # create time vector
 
         self.time_vector = [(s+(datetime.timedelta(int(x))))
                             for x in np.arange(0, t_span, interval)]
@@ -82,20 +82,15 @@ class PriorCreator(metaclass=ABCMeta):
         # get month id/number from self.datestr
         self.date_month_id = self.date.month
 
-    # @abstractmethod
-    # def initialize(self):
-    #     """Initialization routine. Should be implemented in child class.
-    #     Prior calculation is initialized here.
-    #
-    #     :returns: -
-    #     :rtype: -
-    #
-    #     """
-        # assert False, 'Should be implemented in child class'
-
     @abstractmethod
-    def retrieve_prior_file(self):
+    def compute_prior_file(self) -> str:
         """
-        Might perform some computation, then retrieves the path to a file containing
+        Might perform some computation, then retrieves the path to a file containing the prior info
         :return:
+        """
+
+    @classmethod
+    def get_variable_names(cls) -> List[str]:
+        """
+        :return: A list of the variables that this prior creator is able to create priors for
         """

--- a/multiply_prior_engine/prior_creator.py
+++ b/multiply_prior_engine/prior_creator.py
@@ -8,6 +8,7 @@
 """
 
 
+from abc import ABCMeta, abstractmethod
 import datetime
 from dateutil.parser import parse
 import numpy as np
@@ -22,7 +23,7 @@ __email__ = "t.ramsauer@iggf.geo.uni-muenchen.de"
 __status__ = "Prototype"
 
 
-class Prior(object):
+class PriorCreator(metaclass=ABCMeta):
     def __init__(self, **kwargs):
         self.ptype = kwargs.get('ptype', None)
         self.config = kwargs.get('config', None)
@@ -81,12 +82,20 @@ class Prior(object):
         # get month id/number from self.datestr
         self.date_month_id = self.date.month
 
-    def initialize(self):
-        """Initialiszation routine. Should be implemented in child class.
-        Prior calculation is initialized here.
+    # @abstractmethod
+    # def initialize(self):
+    #     """Initialization routine. Should be implemented in child class.
+    #     Prior calculation is initialized here.
+    #
+    #     :returns: -
+    #     :rtype: -
+    #
+    #     """
+        # assert False, 'Should be implemented in child class'
 
-        :returns: -
-        :rtype: -
-
+    @abstractmethod
+    def retrieve_prior_file(self):
         """
-        assert False, 'Should be implemented in child class'
+        Might perform some computation, then retrieves the path to a file containing
+        :return:
+        """

--- a/multiply_prior_engine/prior_creator.py
+++ b/multiply_prior_engine/prior_creator.py
@@ -90,6 +90,7 @@ class PriorCreator(metaclass=ABCMeta):
         """
 
     @classmethod
+    @abstractmethod
     def get_variable_names(cls) -> List[str]:
         """
         :return: A list of the variables that this prior creator is able to create priors for

--- a/multiply_prior_engine/prior_engine.py
+++ b/multiply_prior_engine/prior_engine.py
@@ -14,8 +14,8 @@ import sys
 
 import yaml
 
-from .soilmoisture_prior import RoughnessPrior, SoilMoisturePrior
-from .vegetation_prior import VegetationPrior
+from .soilmoisture_prior_creator import RoughnessPriorCreator, SoilMoisturePriorCreator
+from .vegetation_prior_creator import VegetationPriorCreator
 
 
 __author__ = ["Alexander Löw", "Thomas Ramsauer"]
@@ -56,15 +56,15 @@ class PriorEngine(object):
 
     # TODO ad correct sub routines from Joris
     subengine = {
-        'sm': SoilMoisturePrior,
+        'sm': SoilMoisturePriorCreator,
         'dielectric_const': '',
-        'roughness': RoughnessPrior,
-        'lai': VegetationPrior,
-        'cab': VegetationPrior,
-        'car': VegetationPrior,
-        'cdm': VegetationPrior,
-        'cw': VegetationPrior,
-        'N': VegetationPrior
+        'roughness': RoughnessPriorCreator,
+        'lai': VegetationPriorCreator,
+        'cab': VegetationPriorCreator,
+        'car': VegetationPriorCreator,
+        'cdm': VegetationPriorCreator,
+        'cw': VegetationPriorCreator,
+        'N': VegetationPriorCreator
     }
 
     def __init__(self, **kwargs):
@@ -149,21 +149,19 @@ class PriorEngine(object):
         # test if prior type is specified (else return empty dict):
         try:
             self.config['Prior'][var].keys() is not None
-        except AttributeError as e:
-            logger.warning('[WARNING] No prior type for {}'
-                           ' moisture prior specified!'.format(var))
+        except AttributeError:
+            logger.warning('[WARNING] No prior type for {} prior specified!'.format(var))
             return
         # fill variable specific dictionary with all priors (clim, recent, ..)
         # TODO concatenation necessary? Should a concatenated prior state vector
         # be returned instead/as additional form
         for ptype in self.config['Prior'][var].keys():
 
-            # pass conig and prior type to subclass/engine
+            # pass config and prior type to subclass/engine
             try:
                 logger.info('  ' + ptype + ' prior:')
-                prior = self.subengine[var](ptype=ptype, config=self.config,
-                                       datestr=self.datestr, var=var)
-                var_res.update({ptype: prior.RetrievePrior()})
+                prior = self.subengine[var](ptype=ptype, config=self.config, datestr=self.datestr, var=var)
+                var_res.update({ptype: prior.retrieve_prior_file()})
 
             # If no file is found: module should throw AssertionError
             except AssertionError as e:
@@ -212,6 +210,7 @@ def get_mean_state_vector(datestr: str, variables: list,
             .get_priors())
 
 
+# Todo What do we need this for?
 if __name__ == '__main__':
     print(get_mean_state_vector(
         datestr="2017-03-01", variables=['sm', 'lai', 'cab']))

--- a/multiply_prior_engine/prior_engine.py
+++ b/multiply_prior_engine/prior_engine.py
@@ -137,9 +137,9 @@ class PriorEngine(object):
         var_res = {}
         assert var in self.config['Prior'].keys(), \
             'Variable to be inferred not in config.'
-        
+        print(self.subengine)
         assert var in self.subengine,\
-            ('No sub-enginge defined for variable to be inferred ({}).'
+            ('No sub-engine defined for variable to be inferred ({}).'
              .format(var))
         logger.info('for variable *{}* getting'.format(var))
 

--- a/multiply_prior_engine/prior_engine.py
+++ b/multiply_prior_engine/prior_engine.py
@@ -137,8 +137,7 @@ class PriorEngine(object):
         var_res = {}
         assert var in self.config['Prior'].keys(), \
             'Variable to be inferred not in config.'
-        print(self.subengine)
-        assert var in self.subengine,\
+        assert var in self.subengine.keys(),\
             ('No sub-engine defined for variable to be inferred ({}).'
              .format(var))
         logger.info('for variable *{}* getting'.format(var))

--- a/multiply_prior_engine/soilmoisture_prior_creator.py
+++ b/multiply_prior_engine/soilmoisture_prior_creator.py
@@ -42,7 +42,11 @@ class SoilMoisturePriorCreator(PriorCreator):
     def __init__(self, **kwargs):
         super(SoilMoisturePriorCreator, self).__init__(**kwargs)
 
-    def retrieve_prior_file(self):
+    @classmethod
+    def get_variable_names(cls):
+        return ['sm']
+
+    def compute_prior_file(self):
         """
         Initialize prior specific (climatological, ...) calculation.
 
@@ -344,6 +348,10 @@ class RoughnessPriorCreator(MapPriorCreator):
         """
         return tempfile.mktemp(suffix='.nc')
 
-    def retrieve_prior_file(self):
+    @classmethod
+    def get_variable_names(cls):
+        return ['roughness']
+
+    def compute_prior_file(self):
         assert False, 'roughness prior not implemented'
 

--- a/multiply_prior_engine/soilmoisture_prior_creator.py
+++ b/multiply_prior_engine/soilmoisture_prior_creator.py
@@ -20,7 +20,7 @@ import shapely.wkt
 from netCDF4 import Dataset
 from scipy import spatial
 
-from .prior import Prior
+from .prior_creator import PriorCreator
 
 
 __author__ = ["Alexander Löw", "Thomas Ramsauer"]
@@ -33,16 +33,16 @@ __email__ = "t.ramsauer@iggf.geo.uni-muenchen.de"
 __status__ = "Prototype"
 
 
-class SoilMoisturePrior(Prior):
+class SoilMoisturePriorCreator(PriorCreator):
     """
     Soil moisture prior class.
     Calculation of climatological prior.
     """
 
     def __init__(self, **kwargs):
-        super(SoilMoisturePrior, self).__init__(**kwargs)
+        super(SoilMoisturePriorCreator, self).__init__(**kwargs)
 
-    def RetrievePrior(self):
+    def retrieve_prior_file(self):
         """
         Initialize prior specific (climatological, ...) calculation.
 
@@ -74,7 +74,7 @@ class SoilMoisturePrior(Prior):
             assert os.path.isdir(self.sm_dir), ('Directory does not exist or'
                                                 ' cannot be found: {}'
                                                 .format(self.sm_dir))
-        return self._provide_prior_files()
+        return self._provide_prior_file()
 
     def _calc_climatological_prior(self):
         """
@@ -150,7 +150,7 @@ class SoilMoisturePrior(Prior):
         self.clim_data = Dataset(self.config['Prior']['sm']['climatology']
                                  ['climatology_file'])
 
-    def _provide_prior_files(self):
+    def _provide_prior_file(self):
         """provide file names, bands .. for inference engine
 
         :returns: 2 dictionaries (mean, var) w keys being variables\
@@ -160,7 +160,7 @@ class SoilMoisturePrior(Prior):
 
         """
         # self.date
-        def _get_files(dir, vrt=True):
+        def _get_file(dir, vrt=True):
             """get filenames of climatological prior files from directory.
 
             :param dir: directory conataining the files (mentioned in config)
@@ -223,7 +223,7 @@ class SoilMoisturePrior(Prior):
             else:
                 return '{}{}'.format(dir, fn)
 
-        return (_get_files(self.sm_dir))
+        return (_get_file(self.sm_dir))
 
     def _extract_climatology(self):
         """
@@ -286,7 +286,7 @@ class SoilMoisturePrior(Prior):
         assert False, "recent sm proxy not implemented"
 
 
-class MapPrior(Prior):
+class MapPriorCreator(PriorCreator):
     """
     Prior which is based on a LC map and a LUT
     """
@@ -300,7 +300,7 @@ class MapPrior(Prior):
         lc_file : str
             filename of landcover file
         """
-        super(MapPrior, self).__init__(**kwargs)
+        super(MapPriorCreator, self).__init__(**kwargs)
         self.lut_file = kwargs.get('lut_file', None)
         assert self.lut_file is not None, 'LUT needs to be provided'
 
@@ -312,10 +312,10 @@ class MapPrior(Prior):
         assert os.path.exists(self.lut_file)
 
 
-class RoughnessPrior(MapPrior):
+class RoughnessPriorCreator(MapPriorCreator):
 
     def __init__(self, **kwargs):
-        super(RoughnessPrior, self).__init__(**kwargs)
+        super(RoughnessPriorCreator, self).__init__(**kwargs)
 
     def calc(self):
         if self.ptype == 'climatology':
@@ -343,3 +343,7 @@ class RoughnessPrior(MapPrior):
         save mapped roughness data to file
         """
         return tempfile.mktemp(suffix='.nc')
+
+    def retrieve_prior_file(self):
+        assert False, 'roughness prior not implemented'
+

--- a/multiply_prior_engine/vegetation_prior_creator.py
+++ b/multiply_prior_engine/vegetation_prior_creator.py
@@ -20,7 +20,7 @@ from matplotlib import pyplot as plt
 from scipy import interpolate as RegularGridInterpolator
 from netCDF4 import Dataset
 
-from .prior import Prior
+from .prior_creator import PriorCreator
 
 plt.ion()
 
@@ -115,12 +115,12 @@ def processespercore(varname, PFT, PFT_ids, VegetationPrior):
     return TRAIT_ttf_avg, TRAIT_ttf_unc
 
 
-class VegetationPrior(Prior):
+class VegetationPriorCreator(PriorCreator):
     """
     Description
     """
     def __init__(self, **kwargs):
-        super(VegetationPrior, self).__init__(**kwargs)
+        super(VegetationPriorCreator, self).__init__(**kwargs)
         self.config = kwargs.get('config', None)
         self.priors = kwargs.get('priors', None)
 
@@ -987,20 +987,20 @@ class VegetationPrior(Prior):
         for lon_study in lon_study_:
             for lat_study in lat_study_:
                 print('%3.2f %3.2f' % (lon_study, lat_study))
-                VegPrior.lon_study = [lon_study, lon_study + 10]
-                VegPrior.lat_study = [lat_study, lat_study + 10]
+                vegetation_prior.lon_study = [lon_study, lon_study + 10]
+                vegetation_prior.lat_study = [lat_study, lat_study + 10]
 
                 # 3. Perform Static processing
                 lon, lat, Prior_pbm_avg, Prior_pbm_unc = \
-                  VegPrior.StaticProcessing(variables)
+                  vegetation_prior.StaticProcessing(variables)
 
                 # 4. Perform Static processing
-                VegPrior.DynamicProcessing(variables, lon, lat, Prior_pbm_avg,
-                                           Prior_pbm_unc, doystr=doystr)
+                vegetation_prior.DynamicProcessing(variables, lon, lat, Prior_pbm_avg,
+                                                   Prior_pbm_unc, doystr=doystr)
 
         filenames = self.CombineTiles2Virtualfile(variables)
 
-    def RetrievePrior(self):
+    def retrieve_prior_file(self):
         """FIXME! briefly describe function
 
         :returns: 
@@ -1029,12 +1029,12 @@ class VegetationPrior(Prior):
 
 
 if __name__ == "__main__":
-    VegPrior = VegetationPrior()
+    vegetation_prior = VegetationPriorCreator()
 
     # VegPrior.ProcessData()
-    filenames = VegPrior.RetrievePrior(variables=['lai', 'cab'],
-                                       datestr='2007-12-31 04:23',
-                                       ptype='database')
+    filenames = vegetation_prior.retrieve_prior_file(variables=['lai', 'cab'],
+                                                     datestr='2007-12-31 04:23',
+                                                     ptype='database')
 
     print('%s' % filenames)
     # this should give as output:

--- a/multiply_prior_engine/vegetation_prior_creator.py
+++ b/multiply_prior_engine/vegetation_prior_creator.py
@@ -22,6 +22,8 @@ from netCDF4 import Dataset
 
 from .prior_creator import PriorCreator
 
+SUPPORTED_VARIABLES = ['lai', 'cab', 'cb', 'car', 'cw', 'cdm', 'N', 'ala', 'h', 'bsoil', 'psoil']
+
 plt.ion()
 
 
@@ -159,6 +161,10 @@ class VegetationPriorCreator(PriorCreator):
             'cm': lambda x: (-1 / 100.) * np.log(x),
             'ala': lambda x: 90. * x}
 
+    @classmethod
+    def get_variable_names(cls):
+        return SUPPORTED_VARIABLES
+
     def OfflineProcessing(self):
         """FIXME! briefly describe function
 
@@ -255,8 +261,7 @@ class VegetationPriorCreator(PriorCreator):
         """
 
         # define variables
-        varnames = ['lai', 'cab', 'cb', 'car', 'cw', 'cdm', 'N', 'ala',
-                    'h', 'bsoil', 'psoil']
+        varnames = SUPPORTED_VARIABLES
         descriptions = ['Effective Leaf Area Index',
                         'Leaf Chlorophyll Content', 'Leaf Senescent material',
                         'Leaf Carotonoid Content', 'Leaf Water Content',
@@ -1000,7 +1005,7 @@ class VegetationPriorCreator(PriorCreator):
 
         filenames = self.CombineTiles2Virtualfile(variables)
 
-    def retrieve_prior_file(self):
+    def compute_prior_file(self):
         """FIXME! briefly describe function
 
         :returns: 
@@ -1009,8 +1014,7 @@ class VegetationPriorCreator(PriorCreator):
         """
         # Define variables
         if self.variable is None:
-            self.variables = ['lai', 'cab', 'cb', 'car', 'cw', 'cdm', 'N',
-                              'ala', 'h', 'bsoil', 'psoil']
+            self.variables = SUPPORTED_VARIABLES
 
         # time = parse(self.datestr)
         time = self.date
@@ -1029,14 +1033,13 @@ class VegetationPriorCreator(PriorCreator):
 
 
 if __name__ == "__main__":
-    vegetation_prior = VegetationPriorCreator()
+
+    vegetation_prior = VegetationPriorCreator(var='lai', datestr='2007-12-31 04:23', ptype='database')
 
     # VegPrior.ProcessData()
-    filenames = vegetation_prior.retrieve_prior_file(variables=['lai', 'cab'],
-                                                     datestr='2007-12-31 04:23',
-                                                     ptype='database')
+    filename = vegetation_prior.compute_prior_file()
 
-    print('%s' % filenames)
+    print('%s' % filename)
     # this should give as output:
     #
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from setuptools import setup
 
 requirements = [
+    'abc',
     'python-dateutil',
     'gdal',
     'matplotlib',
@@ -20,13 +21,18 @@ setup(name='multiply-prior-engine',
       description='MULTIPLY Prior Engine',
       author='MULTIPLY Team',
       packages=['multiply_prior_engine'],
-      # entry_points={
+      entry_points={
+          'priors': [
+              'vegetation_prior = multiply_prior_engine:vegetation_prior_creator.VegetationPriorCreator',
+              'soil_moisture_prior = multiply_prior_engine:soil_moisture_prior_creator.SoilMoisturePriorCreator',
+              'roughness_prior = multiply_prior_engine:soil_moisture_prior_creator.RoughnessPriorCreator'
+          ]
       #     'file_system_plugins': [
       #         'local_file_system = multiply_data_access:local_file_system.LocalFileSystemAccessor',
       #     ],
       #     'meta_info_provider_plugins': [
       #         'json_meta_info_provider = multiply_data_access:json_meta_info_provider.JsonMetaInfoProviderAccessor',
       #     ],
-      # },
+      },
       install_requires=requirements
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from setuptools import setup
 
 requirements = [
-    'abc',
     'python-dateutil',
     'gdal',
     'matplotlib',
@@ -22,17 +21,11 @@ setup(name='multiply-prior-engine',
       author='MULTIPLY Team',
       packages=['multiply_prior_engine'],
       entry_points={
-          'priors': [
-              'vegetation_prior = multiply_prior_engine:vegetation_prior_creator.VegetationPriorCreator',
-              'soil_moisture_prior = multiply_prior_engine:soil_moisture_prior_creator.SoilMoisturePriorCreator',
-              'roughness_prior = multiply_prior_engine:soil_moisture_prior_creator.RoughnessPriorCreator'
-          ]
-      #     'file_system_plugins': [
-      #         'local_file_system = multiply_data_access:local_file_system.LocalFileSystemAccessor',
-      #     ],
-      #     'meta_info_provider_plugins': [
-      #         'json_meta_info_provider = multiply_data_access:json_meta_info_provider.JsonMetaInfoProviderAccessor',
-      #     ],
+          'prior_creators': [
+              'vegetation_prior_creator = multiply_prior_engine:vegetation_prior_creator.VegetationPriorCreator',
+              'soil_moisture_prior_creator = multiply_prior_engine:soilmoisture_prior_creator.SoilMoisturePriorCreator',
+              'roughness_prior_creator = multiply_prior_engine:soilmoisture_prior_creator.RoughnessPriorCreator',
+          ],
       },
       install_requires=requirements
 )

--- a/test/prior_engine/test_prior.py
+++ b/test/prior_engine/test_prior.py
@@ -4,9 +4,9 @@ import pytest
 import sys
 myPath = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(myPath + '/../../multiply_prior_engine/')
-from multiply_prior_engine.prior import Prior
+from multiply_prior_engine.prior_creator import PriorCreator
 from multiply_prior_engine.prior_engine import PriorEngine
-from multiply_prior_engine.soilmoisture_prior import SoilMoisturePrior
+from multiply_prior_engine.soilmoisture_prior_creator import SoilMoisturePriorCreator
 
 
 def test_priorengine_init():
@@ -30,29 +30,29 @@ def test_sm_prior_init():
     with pytest.raises(AssertionError,
                        message=("Expecting AssertionError \
                                 --> no config specified")):
-        SoilMoisturePrior()
+        SoilMoisturePriorCreator()
 
 
 def test_sm_prior_no_ptype():
     with pytest.raises(AssertionError,
                        message=("Expecting AssertionError \
                                 --> no config specified")):
-        SoilMoisturePrior()
+        SoilMoisturePriorCreator()
 
 
 def test_sm_prior_invalid_ptype():
     with pytest.raises(AssertionError,
                        message=("Expecting AssertionError \
                                 --> no config specified")):
-        SoilMoisturePrior(ptype='climatologi')
+        SoilMoisturePriorCreator(ptype='climatologi')
 
 
 def test_calc_config():
     P = PriorEngine(config='./test/prior_engine/test_config_prior.yml',
                     datestr='2017-01-01',
                     variables=['sm'])
-    S = SoilMoisturePrior(config=P.config,
-                          ptype='climatology')
+    S = SoilMoisturePriorCreator(config=P.config,
+                                 ptype='climatology')
     assert type(S.config) is dict
 
 

--- a/test/prior_engine/test_prior_engine.py
+++ b/test/prior_engine/test_prior_engine.py
@@ -4,9 +4,7 @@ CONFIG_FILE = './test/prior_engine/prior_engine_test_config.yml'
 
 
 def test_prior_engine():
-    prior_engine = PriorEngine(datestr="2017-03-01",
-                               variables=['sm', 'lai', 'cab'],
-                               config=CONFIG_FILE)
+    prior_engine = PriorEngine(datestr="2017-03-01", variables=['sm', 'lai', 'cab'], config=CONFIG_FILE)
     priors = prior_engine.get_priors()
 
     assert 3, len(priors.keys())


### PR DESCRIPTION
In this branch, I have renamed the class Prior to PriorCreator, and all sub-classes accordingly. A PriorCreator has to implement two methods:

    @abstractmethod
    def compute_prior_file(self) -> str:
        """
        Might perform some computation, then retrieves the path to a file containing the prior info
        :return:
        """

    @classmethod
    def get_variable_names(cls) -> List[str]:
        """
        :return: A list of the variables that this prior creator is able to create priors for
        """

compute_prior_file replaces the method formerly known as RetrievePrior, the latter simply returns a list of variable names.
This approach eliminates all explicit mentions of soilmoisture prior or vegetation prior in the prior engine. It has got quite a few renamings, so please check whether you agree with them. Also, it will probably clash with the user_prior branch, so we might want to merge that one first.
