### PR TITLE
create global vrt

### DIFF
--- a/multiply_prior_engine/soilmoisture_prior_creator.py
+++ b/multiply_prior_engine/soilmoisture_prior_creator.py
@@ -321,7 +321,6 @@ class SoilMoisturePriorCreator(PriorCreator):
             out_fn = os.path.join(self.output_directory, temp_fn)
             vrt_options = gdal.BuildVRTOptions(outputBounds=(-180, -90, 180, 90))
             gdal.BuildVRT(out_fn, fn, options=vrt_options)
-            # TODO VRT is not necessary global.
             res = '{}'.format(out_fn)
             assert os.path.isfile(res), "{} is not a file.".format(res)
             self._check_gdal_compliance(res)

--- a/multiply_prior_engine/soilmoisture_prior_creator.py
+++ b/multiply_prior_engine/soilmoisture_prior_creator.py
@@ -319,7 +319,8 @@ class SoilMoisturePriorCreator(PriorCreator):
                                self.ptype,
                                self.date8))
             out_fn = os.path.join(self.output_directory, temp_fn)
-            gdal.BuildVRT(out_fn, fn)
+            vrt_options = gdal.BuildVRTOptions(outputBounds=(-180, -90, 180, 90))
+            gdal.BuildVRT(out_fn, fn, options=vrt_options)
             # TODO VRT is not necessary global.
             res = '{}'.format(out_fn)
             assert os.path.isfile(res), "{} is not a file.".format(res)

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(name='multiply-prior-engine',
       description='MULTIPLY Prior Engine',
       author='MULTIPLY Team',
       packages=['multiply_prior_engine'],
+      package_data={
+          'multiply_prior_engine': ['*.yml']
+      },
       entry_points={
           'prior_creators': [
               'vegetation_prior_creator = multiply_prior_engine:vegetation_prior_creator.VegetationPriorCreator',


### PR DESCRIPTION
The soil moisture vrt is not global anymore which caused test failures in the inference engine. As the name of the method is _create_global_vrt and we always said we wanted the vrts to be global, I have changed it back to being global.

Is there a reason why it shouldn't be anymore?